### PR TITLE
Yourls api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 feed2omb - a tool for publishing atom/rss feeds to microblogging services
-Copyright (C) 2008-2014, Ciaran Gultnieks
+Copyright (C) 2008-2017, Ciaran Gultnieks
 
 Version 0.9.5
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 feed2omb - a tool for publishing atom/rss feeds to microblogging services
 Copyright (C) 2008-2014, Ciaran Gultnieks
 
-Version 0.9.4
+Version 0.9.5
 
 # Usage
 

--- a/docs/ConfigFiles.mdtext
+++ b/docs/ConfigFiles.mdtext
@@ -37,7 +37,7 @@ Specifies the user's password on the target microblogging service. Example:
 Specifies how urls are shortened. Possible values are:
 
 * lilurl - use a lilURL-based shortening service - specify the host using the urlshortenhost directive
-* yourls - use a [YOURLS](http://yourls.org/)-based shortening service - specify the host using the urlshortenhost directive
+* yourls - use a [YOURLS](http://yourls.org/)-based shortening service - specify the host using the urlshortenhost directive and optionally set urlshortencfg and set an urlshorten key
 * bit.ly - shorten the url using the service at http://bit.ly (default)
 * laconica - assume that Laconica will shorten the url automatically
 * none - do not shorten (drastically reducing available message space)
@@ -52,9 +52,14 @@ If the 'lilurl' or 'yourls' urlshortener is used, this specifies the host to use
 
     urlshortenhost = http://ur1.ca
 
+If the 'yourls' urlshortener is used, you can specifiy a public or private instance here. Example:
+
+    urlshortencfg = public
+
 #urlshortenlogin and urlshortenkey
 
-If using the bit.ly URL shortener, you need to use these to specify your login and API key.
+If using the bit.ly URL shortener, you need to use these to specify your login and API key. 
+If using yourls and urlshortencfg is set to 'private', you need to set an API key.
 
 Example:
 

--- a/feed2omb.py
+++ b/feed2omb.py
@@ -125,7 +125,7 @@ def shorten_lilurl(url, host):
     return (shorturl, len(shorturl))
 
 
-ddef shorten_yourls(url, host):
+def shorten_yourls(url, host):
     try:
         if host is None:
             print "Configuration error - yourls shortener requires a host"

--- a/feed2omb.py
+++ b/feed2omb.py
@@ -125,12 +125,16 @@ def shorten_lilurl(url, host):
     return (shorturl, len(shorturl))
 
 
-def shorten_yourls(url, host):
+ddef shorten_yourls(url, host):
     try:
         if host is None:
             print "Configuration error - yourls shortener requires a host"
             sys.exit(1)
-        params = {'url': url, 'action': 'shorturl', 'format': 'json', 'signature': config['urlshortenkey']}
+        if config['urlshortencfg'] == 'private':
+            signature = config['urlshortenkey']
+            params = {'url': url, 'action': 'shorturl', 'format': 'json', 'signature': signature}
+        else:
+            params = {'url': url, 'action': 'shorturl', 'format': 'json'}
         data = urlencode(params)
         req = urllib2.Request(host + '/yourls-api.php', data)
         response = urllib2.urlopen(req)
@@ -141,7 +145,6 @@ def shorten_yourls(url, host):
         print 'Failed to get short URL'
         shorturl = url
     return (shorturl, len(shorturl))
-
 
 def shorten_none(url, host):
     return (url, len(url))

--- a/feed2omb.py
+++ b/feed2omb.py
@@ -1,8 +1,8 @@
 #
 # feed2omb - a tool for publishing atom/rss feeds to microblogging services
-# Copyright (C) 2008-2014, Ciaran Gultnieks
+# Copyright (C) 2008-2017, Ciaran Gultnieks
 #
-# Version 0.9.4
+# Version 0.9.5
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/sample.config
+++ b/sample.config
@@ -45,7 +45,8 @@ source = feed2omb
 #  lilurl - use a lilURL-based shortening service - specify the host
 #           below (default)
 #  yourls - use a YOURLS-based shortening service - specify the host
-#           below
+#           and optional privacy settings below. If set to private,
+#           urlshortenkey must be set to YOURLS signature token.
 #  bit.ly - shorten the url using the service at http://bit.ly
 #           You need a bit.ly API account and API Key, and you need
 #           to specify the details under urlshortenlogin and
@@ -60,8 +61,14 @@ urlshortener = lilurl
 #here. Otherwise this is ignored.
 urlshortenhost = http://ur1.ca
 
-#If using 'bit.ly' shortening mode, you need to specify your login and
-#API key here.
+#If using 'yourls' shortening mode this may be set to 'private',
+#otherwise ignored.
+urlshortencfg = public
+
+#Authentication settings. Possible values are:
+#  bit.ly - specify your login and API key here. 
+#  yourls - is urlshortencfg is set to private, set an API key. In the
+#           YOURLS admin interface this is the signature token.
 urlshortenlogin = 
 urlshortenkey = 
 


### PR DESCRIPTION
- Add api level access to a yourls url shortener service, fixing the unreliable hack that preceded it
- Allow for public or private YOURLS api access with API signature token integration
- Decode json response to retrieve short url data
- Updated config reflecting changes
- Changed response on short url retrieve failure to provide the original long url rather than NULL 
  - what use is a null result when posting a link as the main body of an update?